### PR TITLE
Add AWS serverless facial recognition example

### DIFF
--- a/face-recognition-terraform/README.md
+++ b/face-recognition-terraform/README.md
@@ -1,0 +1,81 @@
+# Serverless Face Recognition Example
+
+This project demonstrates how to build a facial recognition API on AWS using **Lambda**, **API Gateway**, **S3**, **DynamoDB**, **Rekognition**, and **SNS**. All infrastructure is provisioned with **Terraform**.
+
+## Architecture Overview
+
+- **API Gateway** exposes two endpoints: `/register` and `/recognize`.
+- **Lambda Functions** `RegisterFaceFunction` and `RecognizeFaceFunction` handle face registration and recognition.
+- **S3 Bucket** `face-images-bucket` stores uploaded images with versioning enabled.
+- **Rekognition Collection** `FaceCollection` indexes faces for later searches.
+- **DynamoDB Table** `FaceMetadataTable` stores metadata mapping `faceId` to a `userId` and S3 object key.
+- **SNS Topic** `FaceRegistrationTopic` publishes notifications when a face is registered.
+- **IAM Roles** grant the Lambdas least‑privilege access to S3, Rekognition, DynamoDB, SNS and CloudWatch Logs.
+
+## Files
+
+```
+face-recognition-terraform/
+├── main.tf              # Infrastructure resources
+├── variables.tf         # Input variables
+├── outputs.tf           # Useful outputs (API URLs)
+├── terraform.tfvars     # Example variable values
+├── lambda_register/
+│   ├── index.js
+│   └── package.json
+├── lambda_recognize/
+│   ├── index.js
+│   └── package.json
+└── README.md            # This file
+```
+
+## Running Terraform
+
+1. **Install Terraform** – See [terraform.io](https://www.terraform.io/downloads.html).
+2. **Configure AWS credentials** (environment variables or shared credentials file):
+   ```bash
+   export AWS_ACCESS_KEY_ID=... 
+   export AWS_SECRET_ACCESS_KEY=...
+   export AWS_DEFAULT_REGION=us-east-1
+   ```
+3. **Initialize**:
+   ```bash
+   terraform init
+   ```
+4. **Review the plan**:
+   ```bash
+   terraform plan -out=tfplan
+   ```
+5. **Apply**:
+   ```bash
+   terraform apply tfplan
+   ```
+6. After apply completes, Terraform outputs the API Gateway endpoints. Use them with `curl` to test:
+   ```bash
+   curl -X POST <register_url> \
+     -H "Content-Type: application/json" \
+     -d '{"userId":"user123","imageBase64":"<BASE64>"}'
+
+   curl -X POST <recognize_url> \
+     -H "Content-Type: application/json" \
+     -d '{"imageBase64":"<BASE64>"}'
+   ```
+7. **Inspect Resources** – verify images in S3, records in DynamoDB, and SNS messages in CloudWatch Logs.
+8. **Cleanup** when finished:
+   ```bash
+   terraform destroy -auto-approve
+   ```
+
+## Resource Explanations
+
+Each Terraform resource includes comments describing its purpose. Highlights:
+
+- `aws_s3_bucket.face_images` – stores uploaded images with versioning.
+- `aws_dynamodb_table.face_metadata` – keeps face metadata with a GSI on `userId`.
+- `aws_rekognition_collection.faces` – holds indexed faces for recognition.
+- IAM role policies follow the principle of least privilege so Lambdas can only access required resources.
+- API Gateway methods integrate with the Lambdas using `AWS_PROXY` to forward the request body directly.
+- Outputs expose the invoke URLs so you can easily hit the endpoints.
+
+Terraform automatically manages dependencies. For example, the API deployment waits for methods and integrations using `depends_on`, and Lambda policies reference resources that must exist before they can be attached.
+

--- a/face-recognition-terraform/lambda_recognize/index.js
+++ b/face-recognition-terraform/lambda_recognize/index.js
@@ -1,0 +1,65 @@
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+const rekognition = new AWS.Rekognition();
+const dynamo = new AWS.DynamoDB.DocumentClient();
+
+exports.handler = async (event) => {
+  const start = Date.now();
+  try {
+    const body = typeof event.body === 'string' ? JSON.parse(event.body) : event;
+    const { imageBase64 } = body;
+    if (!imageBase64) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: 'Missing imageBase64' })
+      };
+    }
+
+    const buffer = Buffer.from(imageBase64, 'base64');
+    const key = `recognize/${Date.now()}.jpg`;
+    await s3.putObject({
+      Bucket: process.env.BUCKET_NAME,
+      Key: key,
+      Body: buffer,
+      ContentType: 'image/jpeg'
+    }).promise();
+
+    const searchResp = await rekognition.searchFacesByImage({
+      CollectionId: process.env.FACE_COLLECTION_ID,
+      Image: { S3Object: { Bucket: process.env.BUCKET_NAME, Key: key } },
+      FaceMatchThreshold: 90
+    }).promise();
+
+    let response;
+    if (searchResp.FaceMatches && searchResp.FaceMatches.length > 0) {
+      const match = searchResp.FaceMatches[0];
+      const faceId = match.Face.FaceId;
+      const item = await dynamo.get({
+        TableName: process.env.DYNAMO_TABLE_NAME,
+        Key: { faceId }
+      }).promise();
+      response = {
+        recognized: true,
+        faceId,
+        userId: item.Item ? item.Item.userId : null,
+        confidence: match.Similarity
+      };
+    } else {
+      response = { recognized: false, message: 'No matching face found' };
+    }
+
+    const latency = Date.now() - start;
+    console.log(`Latency: ${latency}ms, Matched: ${response.recognized}`);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response)
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: 'Internal server error' })
+    };
+  }
+};

--- a/face-recognition-terraform/lambda_recognize/package.json
+++ b/face-recognition-terraform/lambda_recognize/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lambda-recognize-face",
+  "version": "1.0.0",
+  "description": "Recognize face Lambda function",
+  "main": "index.js",
+  "dependencies": {}
+}

--- a/face-recognition-terraform/lambda_register/index.js
+++ b/face-recognition-terraform/lambda_register/index.js
@@ -1,0 +1,70 @@
+const AWS = require('aws-sdk');
+const s3 = new AWS.S3();
+const rekognition = new AWS.Rekognition();
+const dynamo = new AWS.DynamoDB.DocumentClient();
+const sns = new AWS.SNS();
+
+exports.handler = async (event) => {
+  try {
+    const body = typeof event.body === 'string' ? JSON.parse(event.body) : event;
+    const { userId, imageBase64 } = body;
+    if (!userId || !imageBase64) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: 'Missing userId or imageBase64' })
+      };
+    }
+
+    const imageBuffer = Buffer.from(imageBase64, 'base64');
+    const timestamp = Date.now();
+    const key = `register/${userId}/${timestamp}.jpg`;
+
+    await s3.putObject({
+      Bucket: process.env.BUCKET_NAME,
+      Key: key,
+      Body: imageBuffer,
+      ContentType: 'image/jpeg'
+    }).promise();
+
+    const indexResp = await rekognition.indexFaces({
+      CollectionId: process.env.FACE_COLLECTION_ID,
+      Image: { S3Object: { Bucket: process.env.BUCKET_NAME, Key: key } },
+      ExternalImageId: userId
+    }).promise();
+
+    const faceRecord = indexResp.FaceRecords && indexResp.FaceRecords[0];
+    if (!faceRecord) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: 'No face detected in image' })
+      };
+    }
+
+    const faceId = faceRecord.Face.FaceId;
+    await dynamo.put({
+      TableName: process.env.DYNAMO_TABLE_NAME,
+      Item: {
+        faceId,
+        userId,
+        s3ObjectKey: key,
+        timestamp
+      }
+    }).promise();
+
+    await sns.publish({
+      TopicArn: process.env.SNS_TOPIC_ARN,
+      Message: `New face registered: ${faceId} for userId: ${userId}`
+    }).promise();
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ faceId, message: 'Face registered successfully' })
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: 'Internal server error' })
+    };
+  }
+};

--- a/face-recognition-terraform/lambda_register/package.json
+++ b/face-recognition-terraform/lambda_register/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lambda-register-face",
+  "version": "1.0.0",
+  "description": "Register face Lambda function",
+  "main": "index.js",
+  "dependencies": {}
+}

--- a/face-recognition-terraform/main.tf
+++ b/face-recognition-terraform/main.tf
@@ -1,0 +1,317 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.2"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+#############################
+# S3 bucket for storing images
+#############################
+resource "aws_s3_bucket" "face_images" {
+  bucket = var.bucket_name
+  versioning {
+    enabled = true
+  }
+  tags = var.project_tags
+}
+
+#############################
+# DynamoDB table for metadata
+#############################
+resource "aws_dynamodb_table" "face_metadata" {
+  name         = var.dynamo_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "faceId"
+
+  attribute {
+    name = "faceId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "userId-index"
+    hash_key        = "userId"
+    projection_type = "ALL"
+  }
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  tags = var.project_tags
+}
+
+#################################
+# Rekognition collection
+#################################
+resource "aws_rekognition_collection" "faces" {
+  collection_id = var.face_collection_id
+  tags          = var.project_tags
+}
+
+#################################
+# SNS topic
+#################################
+resource "aws_sns_topic" "face_registration" {
+  name = var.sns_topic_name
+  tags = var.project_tags
+}
+
+#################################
+# IAM roles and policies
+#################################
+# Role for RegisterFace Lambda
+resource "aws_iam_role" "register_face_role" {
+  name               = "lambda_register_face_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.project_tags
+}
+
+resource "aws_iam_role_policy" "register_face_policy" {
+  name   = "register_face_policy"
+  role   = aws_iam_role.register_face_role.id
+  policy = data.aws_iam_policy_document.register_face_policy.json
+}
+
+# Role for RecognizeFace Lambda
+resource "aws_iam_role" "recognize_face_role" {
+  name               = "lambda_recognize_face_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.project_tags
+}
+
+resource "aws_iam_role_policy" "recognize_face_policy" {
+  name   = "recognize_face_policy"
+  role   = aws_iam_role.recognize_face_role.id
+  policy = data.aws_iam_policy_document.recognize_face_policy.json
+}
+
+#############################
+# IAM policies documents
+#############################
+# Lambda trust policy
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "register_face_policy" {
+  statement {
+    actions = ["s3:PutObject", "s3:GetObject"]
+    resources = ["${aws_s3_bucket.face_images.arn}/*"]
+  }
+  statement {
+    actions   = ["rekognition:IndexFaces"]
+    resources = [aws_rekognition_collection.faces.arn]
+  }
+  statement {
+    actions   = ["dynamodb:PutItem", "dynamodb:GetItem"]
+    resources = [aws_dynamodb_table.face_metadata.arn]
+  }
+  statement {
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.face_registration.arn]
+  }
+  statement {
+    actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+data "aws_iam_policy_document" "recognize_face_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.face_images.arn}/*"]
+  }
+  statement {
+    actions   = ["rekognition:SearchFacesByImage"]
+    resources = [aws_rekognition_collection.faces.arn]
+  }
+  statement {
+    actions   = ["dynamodb:GetItem"]
+    resources = [aws_dynamodb_table.face_metadata.arn]
+  }
+  statement {
+    actions = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:*"]
+  }
+}
+
+#################################
+# Lambda functions packaging
+#################################
+
+data "archive_file" "register_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda_register"
+  output_path = "${path.module}/lambda_register.zip"
+}
+
+data "archive_file" "recognize_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda_recognize"
+  output_path = "${path.module}/lambda_recognize.zip"
+}
+
+resource "aws_lambda_function" "register_face" {
+  function_name = "RegisterFaceFunction"
+  role          = aws_iam_role.register_face_role.arn
+  handler       = "index.handler"
+  runtime       = var.lambda_runtime
+  filename      = data.archive_file.register_zip.output_path
+  source_code_hash = data.archive_file.register_zip.output_base64sha256
+
+  environment {
+    variables = {
+      FACE_COLLECTION_ID = var.face_collection_id
+      DYNAMO_TABLE_NAME  = aws_dynamodb_table.face_metadata.name
+      SNS_TOPIC_ARN      = aws_sns_topic.face_registration.arn
+      BUCKET_NAME        = aws_s3_bucket.face_images.bucket
+    }
+  }
+  tags = var.project_tags
+}
+
+resource "aws_lambda_function" "recognize_face" {
+  function_name = "RecognizeFaceFunction"
+  role          = aws_iam_role.recognize_face_role.arn
+  handler       = "index.handler"
+  runtime       = var.lambda_runtime
+  filename      = data.archive_file.recognize_zip.output_path
+  source_code_hash = data.archive_file.recognize_zip.output_base64sha256
+
+  environment {
+    variables = {
+      FACE_COLLECTION_ID = var.face_collection_id
+      DYNAMO_TABLE_NAME  = aws_dynamodb_table.face_metadata.name
+      BUCKET_NAME        = aws_s3_bucket.face_images.bucket
+    }
+  }
+  tags = var.project_tags
+}
+
+#################################
+# API Gateway
+#################################
+resource "aws_api_gateway_rest_api" "face_api" {
+  name = "FaceRecognitionAPI"
+  tags = var.project_tags
+}
+
+resource "aws_api_gateway_resource" "register" {
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  parent_id   = aws_api_gateway_rest_api.face_api.root_resource_id
+  path_part   = "register"
+}
+
+resource "aws_api_gateway_resource" "recognize" {
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  parent_id   = aws_api_gateway_rest_api.face_api.root_resource_id
+  path_part   = "recognize"
+}
+
+resource "aws_api_gateway_method" "register_post" {
+  rest_api_id   = aws_api_gateway_rest_api.face_api.id
+  resource_id   = aws_api_gateway_resource.register.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method" "recognize_post" {
+  rest_api_id   = aws_api_gateway_rest_api.face_api.id
+  resource_id   = aws_api_gateway_resource.recognize.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "register_integration" {
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  resource_id = aws_api_gateway_resource.register.id
+  http_method = aws_api_gateway_method.register_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.register_face.invoke_arn
+}
+
+resource "aws_api_gateway_integration" "recognize_integration" {
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  resource_id = aws_api_gateway_resource.recognize.id
+  http_method = aws_api_gateway_method.recognize_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.recognize_face.invoke_arn
+}
+
+resource "aws_lambda_permission" "allow_apigw_register" {
+  statement_id  = "AllowAPIGatewayInvokeRegister"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.register_face.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.face_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "allow_apigw_recognize" {
+  statement_id  = "AllowAPIGatewayInvokeRecognize"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.recognize_face.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.face_api.execution_arn}/*/*"
+}
+
+resource "aws_api_gateway_deployment" "prod" {
+  depends_on = [
+    aws_api_gateway_integration.register_integration,
+    aws_api_gateway_integration.recognize_integration
+  ]
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  stage_name  = "prod"
+}
+
+resource "aws_api_gateway_stage" "prod" {
+  rest_api_id = aws_api_gateway_rest_api.face_api.id
+  deployment_id = aws_api_gateway_deployment.prod.id
+  stage_name = "prod"
+  tags       = var.project_tags
+}
+
+
+#################################
+# Optional weekly cleanup rule
+#################################
+resource "aws_cloudwatch_event_rule" "weekly_cleanup" {
+  name                = "WeeklyCleanupRule"
+  schedule_expression = "rate(7 days)"
+  tags                = var.project_tags
+}
+
+resource "aws_cloudwatch_event_target" "cleanup_target" {
+  rule      = aws_cloudwatch_event_rule.weekly_cleanup.name
+  target_id = "CleanupLambda"
+  arn       = aws_lambda_function.register_face.arn
+}
+
+resource "aws_lambda_permission" "allow_events" {
+  statement_id  = "AllowEventsInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.register_face.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.weekly_cleanup.arn
+}

--- a/face-recognition-terraform/outputs.tf
+++ b/face-recognition-terraform/outputs.tf
@@ -1,0 +1,14 @@
+output "register_endpoint" {
+  description = "API Gateway register endpoint"
+  value       = aws_api_gateway_stage.prod.invoke_url != null ? "${aws_api_gateway_stage.prod.invoke_url}register" : ""
+}
+
+output "recognize_endpoint" {
+  description = "API Gateway recognize endpoint"
+  value       = aws_api_gateway_stage.prod.invoke_url != null ? "${aws_api_gateway_stage.prod.invoke_url}recognize" : ""
+}
+
+output "bucket_name" {
+  description = "S3 bucket storing images"
+  value       = aws_s3_bucket.face_images.bucket
+}

--- a/face-recognition-terraform/scripts/list_items.js
+++ b/face-recognition-terraform/scripts/list_items.js
@@ -1,0 +1,15 @@
+const AWS = require('aws-sdk');
+const dynamo = new AWS.DynamoDB.DocumentClient();
+const s3 = new AWS.S3();
+
+async function listTable() {
+  const data = await dynamo.scan({ TableName: process.env.TABLE }).promise();
+  console.log('DynamoDB Items:', JSON.stringify(data.Items, null, 2));
+}
+
+async function listObjects(prefix) {
+  const data = await s3.listObjectsV2({ Bucket: process.env.BUCKET, Prefix: prefix }).promise();
+  console.log('S3 Objects:', data.Contents.map(o => o.Key));
+}
+
+listTable().then(() => listObjects(process.argv[2] || 'register/')).catch(console.error);

--- a/face-recognition-terraform/terraform.tfvars
+++ b/face-recognition-terraform/terraform.tfvars
@@ -1,0 +1,5 @@
+region           = "us-east-1"
+face_collection_id = "FaceCollection"
+dynamo_table_name  = "FaceMetadataTable"
+sns_topic_name     = "FaceRegistrationTopic"
+bucket_name        = "face-images-bucket"

--- a/face-recognition-terraform/variables.tf
+++ b/face-recognition-terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "lambda_runtime" {
+  description = "Lambda runtime"
+  type        = string
+  default     = "nodejs14.x"
+}
+
+variable "face_collection_id" {
+  description = "Rekognition collection ID"
+  type        = string
+  default     = "face-collection"
+}
+
+variable "dynamo_table_name" {
+  description = "DynamoDB table name"
+  type        = string
+  default     = "FaceMetadataTable"
+}
+
+variable "sns_topic_name" {
+  description = "SNS topic name"
+  type        = string
+  default     = "FaceRegistrationTopic"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name"
+  type        = string
+  default     = "face-images-bucket"
+}
+
+variable "project_tags" {
+  description = "Common resource tags"
+  type        = map(string)
+  default = {
+    Project     = "FaceRecognitionProject"
+    Environment = "dev"
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configs to provision S3, DynamoDB, Rekognition, SNS, IAM, Lambda and API Gateway
- implement Lambda functions for registering and recognizing faces
- include optional weekly cleanup event rule and helper script
- provide README with deployment steps and explanations

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842183e9c6c8328bba0558763759ca6